### PR TITLE
Oxford Comma Support

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -11,6 +11,7 @@
 
    - [join(arr)](#joinarr)
    - [join(arr, str)](#joinarr-str)
+   - [join(arr, str) with Oxford comma](#joinarr-str-with-oxford-comma)
 <a name=""></a>
 
 <a name="joinarr"></a>
@@ -32,6 +33,21 @@ join(['foo', 'bar'], 'and').should.equal('foo and bar');
 join(['foo', 'bar', 'raz'], 'or').should.equal('foo, bar or raz');
 ```
 
+<a name="joinarr-str-with-oxford-comma"></a>
+# join(arr, str) with Oxford comma
+should remove comma with less than 3 items.
+
+```js
+join([], ', or').should.equal('');
+join(['foo'], ', or').should.equal('foo');
+join(['foo', 'bar'], ', or').should.equal('foo or bar');
+```
+
+should join with 3 or more items.
+
+```js
+join(['foo', 'bar', 'raz'], ', and').should.equal('foo, bar, and raz');
+```
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -13,7 +13,16 @@
 module.exports = function(arr, str, sep){
   str = str || 'and';
   sep = sep || ', ';
-  str = ' ' + str + ' ';
+
   if (arr.length < 2) return arr[0] || '';
-  return arr.slice(0, -1).join(sep) + str + arr[arr.length - 1];
+
+  var oxford = str.slice(0, 2) === sep;
+
+  if (!oxford) {
+    str = ' ' + str;
+  } else if (arr.length == 2) {
+    str = str.slice(1);
+  }
+
+  return arr.slice(0, -1).join(sep) + str + ' ' + arr[arr.length - 1];
 };

--- a/test/index.js
+++ b/test/index.js
@@ -15,3 +15,15 @@ describe('join(arr, str)', function(){
      join(['foo', 'bar', 'raz'], 'or').should.equal('foo, bar or raz');
   })
 })
+
+describe('join(arr, str) with Oxford comma', function() {
+  it('should remove comma with less than 3 items', function() {
+    join([], ', or').should.equal('');
+    join(['foo'], ', or').should.equal('foo');
+    join(['foo', 'bar'], ', or').should.equal('foo or bar');
+  })
+
+  it('should join with 3 or more items', function() {
+    join(['foo', 'bar', 'raz'], ', and').should.equal('foo, bar, and raz');
+  })
+})


### PR DESCRIPTION
Per #1, added the ability to use the existing API to support [Oxford commas](http://oxforddictionaries.com/words/what-is-the-oxford-comma).

This is achieved by simply checking if the supplied conjunction (e.g. `and`) is preceded by the separator (e.g. `,`), such as `, and`.  When true and there are fewer than 3 elements, the separator is sliced off.
- Created tests
- Modified `join` to support Oxford comma
- Updated README via `mocha --reporter markdown test/index.js`
